### PR TITLE
fix: исправлено сохранение значения свойства элемента HL

### DIFF
--- a/lib/iblockfield.php
+++ b/lib/iblockfield.php
@@ -66,7 +66,7 @@ class IBlockField
         return '';
     }
 
-    public static function GetAdminListViewHTML($arProperty, $value, $strHTMLControlName)
+    public static function GetAdminListViewHTML($arProperty, $value, $strHTMLControlName = '')
     {
         if (!is_array($value["VALUE"]))
             $value = static::ConvertFromDB($arProperty, $value);
@@ -157,7 +157,7 @@ class IBlockField
     }
 
     // для uf-поля
-    public static function OnBeforeSave($arProperty, $value)
+    public static function OnBeforeSave($arProperty, $value, $user_id = 0)
     {
         $value = self::ConvertToDB($arProperty, ['VALUE' => $value]);
         return $value['VALUE'];

--- a/lib/iblockfield.php
+++ b/lib/iblockfield.php
@@ -157,7 +157,7 @@ class IBlockField
     }
 
     // для uf-поля
-    public static function OnBeforeSave($arProperty, $value, $user_id)
+    public static function OnBeforeSave($arProperty, $value)
     {
         $value = self::ConvertToDB($arProperty, ['VALUE' => $value]);
         return $value['VALUE'];


### PR DESCRIPTION
При сохранении значения свойства элемента HL в метод OnBeforeSave передается 2 параметра. 
![image](https://user-images.githubusercontent.com/18091497/228863299-228deea8-311d-454e-ac6e-9b6d79ff2684.png)
Метод в модуле ожидает 3 параметра. 
Из-за этого при сохранении возникает ошибка.
